### PR TITLE
[VELRM-1313] Добавлены userData и os_username, а также новое API получения ссылки на VNC

### DIFF
--- a/src/Compute/v2/Api.php
+++ b/src/Compute/v2/Api.php
@@ -347,6 +347,7 @@ class Api extends AbstractApi
                 'name'        => $this->params->name('server'),
                 'metadata'    => $this->notRequired($this->params->metadata()),
                 'adminPass'   => $this->params->password(),
+                'userData'    => $this->params->userData(),
             ],
         ];
     }
@@ -453,54 +454,16 @@ class Api extends AbstractApi
         ];
     }
 
-    public function getVncConsole(): array
+    public function getConsole(): array
     {
         return [
             'method'  => 'POST',
-            'path'    => 'servers/{id}/action',
-            'jsonKey' => 'os-getVNCConsole',
+            'path'    => 'servers/{id}/remote-consoles',
+            'jsonKey' => 'remote_console',
             'params'  => [
-                'id'   => $this->params->urlId('server'),
-                'type' => $this->params->consoleType(),
-            ],
-        ];
-    }
-
-    public function getSpiceConsole(): array
-    {
-        return [
-            'method'  => 'POST',
-            'path'    => 'servers/{id}/action',
-            'jsonKey' => 'os-getSPICEConsole',
-            'params'  => [
-                'id'   => $this->params->urlId('server'),
-                'type' => $this->params->consoleType(),
-            ],
-        ];
-    }
-
-    public function getSerialConsole(): array
-    {
-        return [
-            'method'  => 'POST',
-            'path'    => 'servers/{id}/action',
-            'jsonKey' => 'os-getSerialConsole',
-            'params'  => [
-                'id'   => $this->params->urlId('server'),
-                'type' => $this->params->consoleType(),
-            ],
-        ];
-    }
-
-    public function getRDPConsole(): array
-    {
-        return [
-            'method'  => 'POST',
-            'path'    => 'servers/{id}/action',
-            'jsonKey' => 'os-getRDPConsole',
-            'params'  => [
-                'id'   => $this->params->urlId('server'),
-                'type' => $this->params->consoleType(),
+                'id'        => $this->params->urlId('server'),
+                'protocol'  => $this->params->consoleProtocol(),
+                'type'      => $this->params->consoleType(),
             ],
         ];
     }
@@ -886,45 +849,6 @@ class Api extends AbstractApi
                 'securityGroups'           => $this->notRequired($this->params->quotaSetLimitSecurityGroups()),
                 'serverGroups'             => $this->notRequired($this->params->quotaSetLimitServerGroups()),
                 'serverGroupMembers'       => $this->notRequired($this->params->quotaSetLimitServerGroupMembers()),
-            ],
-        ];
-    }
-
-    public function getExtraSpecs(): array
-    {
-        return [
-            'method'  => 'GET',
-            'path'    => 'flavors/{flavorId}/os-extra_specs',
-            'params'  => [
-                'flavorId' => $this->params->urlId('flavor')
-            ],
-        ];
-    }
-
-    public function postExtraSpecs(): array
-    {
-        return [
-            'method'  => 'POST',
-            'path'    => 'flavors/{flavorId}/os-extra_specs',
-            'jsonKey' => 'extra_specs',
-            'params'  => [
-                'flavorId' => $this->params->urlId('flavor'),
-                'diskTotalIopsSec' => $this->notRequired($this->params->extraSpecsSetDiskTotalIopsSec()),
-                'diskReadBytesSec' => $this->notRequired($this->params->extraSpecsSetDiskReadBytesSec()),
-                'diskWriteBytesSec' => $this->notRequired($this->params->extraSpecsSetDiskWriteBytesSec()),
-                'diskTotalBytesSec' => $this->notRequired($this->params->extraSpecsSetDiskTotalBytesSec()),
-            ],
-        ];
-    }
-
-    public function deleteExtraSpec(): array
-    {
-        return [
-            'method'  => 'DELETE',
-            'path'    => 'flavors/{flavorId}/os-extra_specs/{extraSpecKey}',
-            'params'  => [
-                'flavorId' => $this->params->urlId('flavor'),
-                'extraSpecKey' => $this->params->extraSpecKey(),
             ],
         ];
     }

--- a/src/Compute/v2/Models/Server.php
+++ b/src/Compute/v2/Models/Server.php
@@ -321,47 +321,18 @@ class Server extends OperatorResource implements Creatable, Updateable, Deletabl
      * @param string $type the type of VNC console: novnc|xvpvnc.
      *                     Defaults to novnc
      */
-    public function getVncConsole($type = Enum::CONSOLE_NOVNC): array
+    public function getConsole($type = Enum::CONSOLE_NOVNC): array
     {
-        $response = $this->execute($this->api->getVncConsole(), ['id' => $this->id, 'type' => $type]);
+        $response = $this->execute(
+            $this->api->getConsole(),
+            [
+                'id' => $this->id,
+                'protocol' => 'vnc',
+                'type' => $type
+            ]
+        );
 
-        return Utils::jsonDecode($response)['console'];
-    }
-
-    /**
-     * Gets a RDP console for a server.
-     *
-     * @param string $type the type of VNC console: rdp-html5 (default)
-     */
-    public function getRDPConsole($type = Enum::CONSOLE_RDP_HTML5): array
-    {
-        $response = $this->execute($this->api->getRDPConsole(), ['id' => $this->id, 'type' => $type]);
-
-        return Utils::jsonDecode($response)['console'];
-    }
-
-    /**
-     * Gets a Spice console for a server.
-     *
-     * @param string $type the type of VNC console: spice-html5
-     */
-    public function getSpiceConsole($type = Enum::CONSOLE_SPICE_HTML5): array
-    {
-        $response = $this->execute($this->api->getSpiceConsole(), ['id' => $this->id, 'type' => $type]);
-
-        return Utils::jsonDecode($response)['console'];
-    }
-
-    /**
-     * Gets a serial console for a server.
-     *
-     * @param string $type the type of VNC console: serial
-     */
-    public function getSerialConsole($type = Enum::CONSOLE_SERIAL): array
-    {
-        $response = $this->execute($this->api->getSerialConsole(), ['id' => $this->id, 'type' => $type]);
-
-        return Utils::jsonDecode($response)['console'];
+        return Utils::jsonDecode($response)['remote_console'];
     }
 
     /**

--- a/src/Compute/v2/Params.php
+++ b/src/Compute/v2/Params.php
@@ -543,6 +543,15 @@ EOL
         ];
     }
 
+    public function consoleProtocol(): array
+    {
+        return [
+            'type'     => self::STRING_TYPE,
+            'location' => self::JSON,
+            'required' => true,
+        ];
+    }
+
     public function consoleType(): array
     {
         return [
@@ -656,44 +665,5 @@ EOL
     public function quotaSetLimitServerGroupMembers(): array
     {
         return $this->quotaSetLimit('server_group_members', 'The number of allowed members for each server group.');
-    }
-
-    protected function extraSpecsSetInt($sentAs, $description): array
-    {
-        return [
-            'type'        => self::INT_TYPE,
-            'location'    => self::JSON,
-            'sentAs'      => $sentAs,
-            'description' => $description,
-        ];
-    }
-
-    public function extraSpecsSetDiskTotalIopsSec(): array
-    {
-        return $this->extraSpecsSetInt('quota:disk_total_iops_sec', 'Specifies the upper limit for disk utilization in I/O per second. The utilization of a virtual machine will not exceed this limit, even if there are available resources. The default value is -1 which indicates unlimited usage.');
-    }
-
-    public function extraSpecsSetDiskWriteBytesSec(): array
-    {
-        return $this->extraSpecsSetInt('quota:disk_write_bytes_sec', 'Specifies the maximum disk write speed in bytes per second for a VM user.');
-    }
-
-    public function extraSpecsSetDiskReadBytesSec(): array
-    {
-        return $this->extraSpecsSetInt('quota:disk_read_bytes_sec', 'Specifies the maximum disk read speed in bytes per second for a VM user.');
-    }
-
-    public function extraSpecsSetDiskTotalBytesSec(): array
-    {
-        return $this->extraSpecsSetInt('quota:disk_total_bytes_sec', 'Specifies the maximum disk read/write speed in bytes per second for a VM user.');
-    }
-
-    public function extraSpecKey(): array
-    {
-        return [
-            'type'        => self::STRING_TYPE,
-            'location'    => self::URL,
-            'description' => 'Extra spec key.',
-        ];
     }
 }

--- a/src/Images/v2/Models/Image.php
+++ b/src/Images/v2/Models/Image.php
@@ -74,6 +74,13 @@ class Image extends OperatorResource implements Creatable, Listable, Retrievable
     /** @var int */
     public $virtualSize;
 
+    /**
+     * Custom metadata field for Velvica needs.
+     *
+     * @var string
+     */
+    public $osUsername;
+
     private $jsonSchema;
 
     protected $aliases = [
@@ -83,6 +90,7 @@ class Image extends OperatorResource implements Creatable, Listable, Retrievable
         'owner'            => 'ownerId',
         'min_ram'          => 'minRam',
         'virtual_size'     => 'virtualSize',
+        'os_username'      => 'osUsername',
     ];
 
     /**


### PR DESCRIPTION
## Описание

Три изменения.

1. Чтобы [Nova](https://docs.openstack.org/api-ref/compute/?expanded=rebuild-server-rebuild-action-detail) поддерживала передачу метаданных userData, нужно указывать microVersion 2.57.
![image](https://user-images.githubusercontent.com/924977/89622790-3e4db800-d89c-11ea-9316-e64ac110a5c8.png)
Добавил этот параметр в число передаваемых.

2. При microVersion > 2.39 нельзя использовать проксированные вызовы к Images API из Compute API, поэтому os_username теперь берётся из Images API.

3. Аналогично в новой Nova поменялся способ получения ссылки на VNC, тоже поменяно.